### PR TITLE
Fix suspicious TLD list typing for heuristics

### DIFF
--- a/src/data/tlds_suspicious.ts
+++ b/src/data/tlds_suspicious.ts
@@ -1,4 +1,4 @@
-export const SUSPICIOUS_TLDS: readonly string[] = [
+export const SUSPICIOUS_TLDS = [
   '.zip',
   '.mov',
   '.xyz',
@@ -24,4 +24,12 @@ export const SUSPICIOUS_TLDS: readonly string[] = [
   '.best',
   '.biz',
   '.win'
-];
+] as const satisfies readonly string[];
+
+export type SuspiciousTld = (typeof SUSPICIOUS_TLDS)[number];
+
+const suspiciousTldSet: ReadonlySet<string> = new Set(SUSPICIOUS_TLDS);
+
+export function isSuspiciousTld(tld: string): tld is SuspiciousTld {
+  return suspiciousTldSet.has(tld);
+}

--- a/src/lib/heuristics.ts
+++ b/src/lib/heuristics.ts
@@ -1,5 +1,5 @@
 import { KNOWN_SHORTENER_DOMAINS } from '../data/shorteners';
-import { SUSPICIOUS_TLDS } from '../data/tlds_suspicious';
+import { isSuspiciousTld } from '../data/tlds_suspicious';
 import { SUSPICIOUS_KEYWORDS } from '../data/keywords';
 import type { UrlAnalysisOptions, UrlAnalysisResult, Verdict } from '../types';
 import { expandUrl } from './expand';
@@ -38,7 +38,7 @@ function tldFromHost(host: string): string | null {
 function hasSuspiciousTld(host: string): string | null {
   const tld = tldFromHost(host);
   if (!tld) return null;
-  return SUSPICIOUS_TLDS.includes(tld) ? tld : null;
+  return isSuspiciousTld(tld) ? tld : null;
 }
 
 function hasPunycode(host: string): boolean {


### PR DESCRIPTION
## Summary
- flatten the suspicious TLD definition to a single export that leverages `as const satisfies` for readonly typing
- keep the literal union type and set-backed helper without introducing an extra intermediary array

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68eabe257a2c83218653f91196cc6981